### PR TITLE
Keep the same indent as the current line have

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -354,16 +354,17 @@ function! VimTodoListsAppendDate()
   endif
 endfunction
 
-" Creates a new item above the current line
+" Creates a new item above the current line with the same indent
 function! VimTodoListsCreateNewItemAbove()
-  normal! O- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! O" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 
-
-" Creates a new item below the current line
+" Creates a new item below the current line with the same indent
 function! VimTodoListsCreateNewItemBelow()
-  normal! o- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! o" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 


### PR DESCRIPTION
Makes expectation more obvious when append near a child item
a new one (using 'O' or 'o')